### PR TITLE
画像アップロード機能を使用しない時はファイルの説明を表示しないように。

### DIFF
--- a/theme/mono_main.html
+++ b/theme/mono_main.html
@@ -262,8 +262,9 @@
 								<figure>
 									<figcaption>
 										<a href="<% echo(oya/res/src) %>" title="<% echo(oya/res/sub) %>" target="_blank"><% echo(oya/res/srcname) %></a> (<% echo(oya/res/size) %> B)<% def(oya/res/thumb) %> - サムネイル表示中 -<% /def %><% def(oya/res/painttime) %>  PaintTime :<% echo(oya/res/painttime) %>
+										<% /def %>
 										<br>
-										<% /def %><% def(oya/res/continue) %>
+										<% def(oya/res/continue) %>
 										<a href="<% echo(self) %>?mode=continue&amp;no=<% echo(oya/res/continue) %>">●続きを描く</a><% /def %><% def(oya/res/pch) %> <a href="<% echo(self) %>?mode=openpch&amp;pch=<% echo(oya/res/pch) %>" target="_blank">●動画</a><% /def %>
 										
 									</figcaption>

--- a/theme/mono_other.html
+++ b/theme/mono_other.html
@@ -149,8 +149,10 @@
 						</table>
 						<% def(regist) %>
 						<ul>
+							<% def(upfile) %>
 							<li>添付可能ファイル：GIF, JPG, PNG ブラウザによっては正常に添付できないことがあります。</li>
 							<li>画像は横 <% echo(maxw) %>ピクセル、縦 <% echo(maxh) %>ピクセルを超えると縮小表示されます。</li>
+							<% /def %>
 							<li>最大投稿データ量は <% echo(maxkb) %> KB までです。sage機能付き。</li>
 							<% def(rewrite) %>
 							<li>編集では クッキーは保存されません。さらにsageを入れても位置は変わりません。</li>

--- a/theme_nee2/nee2_other.html
+++ b/theme_nee2/nee2_other.html
@@ -124,8 +124,10 @@
 						</table>
 						<% def(regist) %>
 						<ul>
+							<% def(upfile) %>
 							<li>添付可能ファイル：GIF, JPG, PNG ブラウザによっては正常に添付できないことがあります。</li>
 							<li>画像は横 <% echo(maxw) %>ピクセル、縦 <% echo(maxh) %>ピクセルを超えると縮小表示されます。</li>
+							<% /def %>
 							<li>最大投稿データ量は <% echo(maxkb) %> KB までです。sage機能付き。</li>
 							<% def(rewrite) %>
 							<li>編集では クッキーは保存されません。さらにsageを入れても位置は変わりません。</li>


### PR DESCRIPTION
```
<% def(upfile) %>
<li>添付可能ファイル：GIF, JPG, PNG ブラウザによっては正常に添付できないことがあります。</li>
<li>画像は横 <% echo(maxw) %>ピクセル、縦 <% echo(maxh) %>ピクセルを超えると縮小表示されます。</li>
<% /def %>
```
POTI本体に画像アップロード機能を使う、使わないの設定ができたので、
画像アップロード機能を使わない時はアップロードに関する説明文を表示しないように修正ました。
CSSはいじっていませんので、CSSのプルリクとは競合しない筈…です。
よろしくお願いします。
