### PR TITLE
管理者の編集画面に画像アップロード欄がでるバグを修正。管理画面に画像アップ欄を出す出さないの判定をPOTI本体で。

### DIFF
--- a/theme/mono_other.html
+++ b/theme/mono_other.html
@@ -131,13 +131,6 @@
 								<td>UpFile</td>
 								<td><input class="form" type="file" name="upfile" size="35"> [<label><input type="checkbox" name="textonly" value="on">No File</label>]</td>
 							</tr>
-							<% elsedef %>
-							<% def(admin) %>
-							<tr>
-								<td>UpFile</td>
-								<td><input class="form" type="file" name="upfile" size="35"> [<label><input type="checkbox" name="textonly" value="on">No File</label>]</td>
-							</tr>
-							<% /def %>
 							<% /def %>
 							<% def(tmp) %>
 							<tr>

--- a/theme_nee2/nee2_other.html
+++ b/theme_nee2/nee2_other.html
@@ -106,13 +106,6 @@
 								<td>UpFile</td>
 								<td><input class="form" type="file" name="upfile" size="35"> [<label><input type="checkbox" name="textonly" value="on">No File</label>]</td>
 							</tr>
-							<% elsedef %>
-							<% def(admin) %>
-							<tr>
-								<td>UpFile</td>
-								<td><input class="form" type="file" name="upfile" size="35"> [<label><input type="checkbox" name="textonly" value="on">No File</label>]</td>
-							</tr>
-							<% /def %>
 							<% /def %>
 							<% def(tmp) %>
 							<tr>


### PR DESCRIPTION
バグ修正。POTI本体とセット。
「管理パス」で編集すると画像アップロード欄が表示されるバグの修正です。
お手数をおかけしますがよろしくお願いします。