### PR TITLE
投稿者名をコピーボタンでレス投稿者名をコメント欄に入力できるように改良

### DIFF
--- a/theme/mono_main.html
+++ b/theme/mono_main.html
@@ -83,8 +83,11 @@
 					レス送信モード
 					<% each(oya) %>
 					<% def(resname) %>
-					<!--コピー対象要素とコピーボタン-->
-					<input class="copy_txt" id="t" type="text" value="<% echo(resname) %>さん" readonly><button class="copy_button" onclick="c()">投稿者名をコピー</button><script>function c(){var copyTarget;document.getElementById("t").select(),document.execCommand("Copy")}</script>
+					<script>function add_to_com(){
+						document.getElementById("p_input_com").value += "<% echo(resname) %>さん";
+						}</script>
+					
+					<% コピーボタン %><button class="copy_button" onclick="add_to_com()">投稿者名をコピー</button>
 					<% /def %>
 					<% /each %>
 				</p>
@@ -184,7 +187,7 @@
 							</tr>
 							<tr>
 								<td>com<% def(usecom) %><% echo(usecom) %><% /def %></td>
-								<td><textarea class="form" name="com" cols="28" rows="4" wrap="soft"></textarea></td>
+								<td><textarea class="form" name="com" cols="28" rows="4" wrap="soft" id="p_input_com"></textarea></td>
 							</tr>
 							<% def(upfile) %>
 							<tr>

--- a/theme/readme.md
+++ b/theme/readme.md
@@ -34,6 +34,7 @@ Skinnyのタグは[本家](http://skinny.sx68.net/tag/taglist.html)を見てい�
 - def(paint) - お絵かき機能を使う時。
 - def(applet) - 「しぃペインター」を使う時。
 - def(paint2) - 「お絵かき機能を使用する お絵かきのみ」(define('USE_PAINT', '2');)の設定の場合です。
+- def(for_new_post) - 新規投稿フォームからの投稿が有効な設定の時にTrueが入ります。
 - echo(pdefw) - デフォルトのお絵かきサイズ幅です。
 - echo(pdefh) - デフォルトのお絵かきサイズ高さです。
 - def(anime) - 動画記録を使用するかどうかです。

--- a/theme_nee2/nee2_main.html
+++ b/theme_nee2/nee2_main.html
@@ -50,8 +50,10 @@
 					レス送信モード
 					<% each(oya) %>
 					<% def(resname) %>
-					<!--コピー対象要素とコピーボタン-->
-					<input class="copy_txt" id="t" type="text" value="<% echo(resname) %>さん" readonly><button class="copy_button" onclick="c()">投稿者名をコピー</button><script>function c(){var copyTarget;document.getElementById("t").select(),document.execCommand("Copy")}</script>
+					<script>function add_to_com(){
+						document.getElementById("p_input_com").value += "<% echo(resname) %>さん";
+						}</script>
+					<% コピーボタン %><button class="copy_button" onclick="add_to_com()">投稿者名をコピー</button>
 					<% /def %>
 					<% /each %>
 				</p>
@@ -119,7 +121,7 @@
 							</tr>
 							<tr>
 								<td>com<% def(usecom) %><% echo(usecom) %><% /def %></td>
-								<td><textarea class="form" name="com" cols="28" rows="4" wrap="soft"></textarea></td>
+								<td><textarea class="form" name="com" cols="28" rows="4" wrap="soft" id="p_input_com"></textarea></td>
 							</tr>
 							<% def(upfile) %>
 							<tr>


### PR DESCRIPTION
`<textarea class="form" name="com" cols="28" rows="4" wrap="soft" id="p_input_com">`
JavaScriptで、id="p_input_com" を指定しているため、ここのidを変更する時は、JavaScriptの
`document.getElementById("p_input_com").value += "<% echo(resname) %>さん";`
も変更する必要があります。
`id="p_input_com"`
は
CSSのためのidではなく、JavaScriptのためのidです。