### PR TITLE
カタログモードのlightbox.css

### DIFF
--- a/theme/mono_catalog.html
+++ b/theme/mono_catalog.html
@@ -30,7 +30,7 @@
 			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.css" type="text/css">
 		</noscript>
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.6/css/all.css">
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css">
+		<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css"> -->
 		<title><% echo(title) %></title>
 	</head>
 	<body>

--- a/theme/mono_paint.html
+++ b/theme/mono_paint.html
@@ -446,6 +446,7 @@
 			<!-- (========== 動画表示モード ==========) -->
 			<article id="appstage">
 				<div class="app">
+					<div style="width:<% echo(w) %>px; height:<% echo(h) %>px">
 					<% def(paintbbs) %>
 					<applet-dummy code="pch.PCHViewer.class" archive="PCHViewer.jar,PaintBBS.jar" name="pch" width="<% echo(w) %>" height="<% echo(h) %>" mayscript>
 					<% /def %>
@@ -469,6 +470,7 @@
 					<% def(normal) %>
 					</applet>
 					<% /def %>
+					</div>
 					<p>
 						<a href="<% echo(pchfile) %>" target="_blank">Download</a> - Datasize : <% echo(datasize) %> byte
 					</p>

--- a/theme_nee2/nee2_catalog.html
+++ b/theme_nee2/nee2_catalog.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 		<link rel="stylesheet" href="<% echo(skindir) %>nee2_main.css" type="text/css">
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.6/css/all.css">
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css">
+		<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css"> -->
 		<title><% echo(title) %></title>
 	</head>
 	<body>

--- a/theme_nee2/nee2_paint.html
+++ b/theme_nee2/nee2_paint.html
@@ -416,6 +416,7 @@
 			<% def(pch_mode) %>
 			<section id="appstage">
 				<div class="app">
+					<div style="width:<% echo(w) %>px; height:<% echo(h) %>px">
 					<% def(paintbbs) %>
 					<applet-dummy code="pch.PCHViewer.class" archive="PCHViewer.jar,PaintBBS.jar" name="pch" width="<% echo(w) %>" height="<% echo(h) %>" mayscript>
 					<% /def %>
@@ -439,6 +440,7 @@
 					<% def(normal) %>
 					</applet>
 					<% /def %>
+					</div>
 					<p>
 						<a href="<% echo(pchfile) %>" target="_blank">Download</a> - Datasize : <% echo(datasize) %> byte
 					</p>


### PR DESCRIPTION
### pchViewerで再生する時にあらかじめ高さ確保しておく

![Screen-2020-08-12_15-34-04](https://user-images.githubusercontent.com/44894014/89987266-b7904500-dcb8-11ea-9715-bcca81c52cb8.png)
↑
従来はこうなっていましたが…。

![Screen-2020-08-12_15-36-44](https://user-images.githubusercontent.com/44894014/89987271-bb23cc00-dcb8-11ea-8d59-6c492697e0fd.png)
↑
NEOのViewerの高さが出る前にdivにスタイルを直接指定して、あらかじめ幅と高さを確保するようにしました。

Googleで速度テストをしてみたら

### lightbox.css
> css/lightbox.css(cdnjs.cloudflare.com) | 1.6 KiB | 780 ms

カタログでは使っていないようでしたので、コメントアウトしました。

よろしくお願いします。
